### PR TITLE
Create cron job to automatically delete old files

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,14 +7,15 @@
 - [x] **URL Detection**: Extract URLs using regex or other filters.
 - [x] **Drag-and-Drop Area**: Accepts various file types (PDF, image).
 - [x] **Logo Overlay in QR**: Embed a small image/logo in the center of the QR code.
-- [x] **QR code colors**: Allow users to customize the foreground and background colors of the QR code.
+- [x] **QR Code Colors**: Allow users to customize the foreground and background colors of the QR code.
 - [x] **Error Correction Handling**: Adjust error correction levels based on whether a logo is used.
 - [x] **Share Functionality**: Copy QR codes to clipboard or download QR images.
 - [x] **Supabase Authentication**: Enable user login (e.g., email/password, Google) to restrict file-related QR code generation to logged-in users.
 - [x] **Connect Supabase to Frontend**: Integrate Supabase SDK into the frontend to handle file uploads, authentication, and database operations directly from the React app.
 - [x] **Supabase Storage**: Configure Supabase Storage to securely store uploaded files (images and PDFs). Generate public URLs for these files to embed in QR codes. Set up storage rules to enforce file size limits (max 10MB) and restrict uploads to authenticated users.
 - [x] **Rate Limit**: Track and enforce rate limiting (max 3 file-related QR codes per user) using Supabase's database and row-level security (RLS) policies.
-- [ ] **User Storage Management**: Allow users to view, manage, and delete their uploaded files directly from the app.
-- [ ] **Delete Old Files**: Use a cron job to automatically delete files that are over a week old to free up Supabase storage space and maintain system efficiency.
+- [x] **User Storage Management**: Allow users to view, manage, and delete their uploaded files directly from the app.
+- [x] **Account Deletion**: Implement functionality to allow users to delete their account and all associated data.
+- [x] **Delete Old Files**: Use a cron job to automatically delete files that are over a week old to free up Supabase storage space and maintain system efficiency.
 - [ ] **Deploy Demo**: Publish demo version of the end product via GitHub pages (Only frontend).
 - [ ] **Documentation**: Write a README.md file to explain the app's features, setup instructions, and usage guidelines.

--- a/client/src/components/StorageQrCodeDetails.tsx
+++ b/client/src/components/StorageQrCodeDetails.tsx
@@ -1,6 +1,7 @@
 import { useContext, type FC } from "react";
 import { Button } from "./Button";
 import PdfIcon from "../assets/icons/pdf.svg";
+import RefreshIcon from "../assets/icons/refresh.svg?react";
 import { LanguageContext } from "../contexts/LanguageContext";
 import type { SupabaseUserFilesSchema } from "../types/Supabase";
 import { getFilePreviewType } from "../utils/getFilePreviewType";
@@ -8,12 +9,14 @@ import { truncateFileName } from "../utils/truncateFileName";
 
 interface StorageQrCodeDetailsProps {
   file: SupabaseUserFilesSchema;
-  deleteFile: (fileId: string) => void;
+  deleteFile: (fileName: string) => void;
+  refreshDeleteDate: (fileId: string) => void;
 }
 
 export const StorageQrCodeDetails: FC<StorageQrCodeDetailsProps> = ({
   file,
   deleteFile,
+  refreshDeleteDate,
 }) => {
   const lang = useContext(LanguageContext);
 
@@ -27,6 +30,15 @@ export const StorageQrCodeDetails: FC<StorageQrCodeDetailsProps> = ({
     month: "long",
     day: "numeric",
   });
+
+  const autoDeleteTime = autoDeleteDate.getHours() < 12 ? "12:00" : "00:00";
+
+  const fileUpdatedAt = new Date(file.updated_at);
+  const today = new Date();
+  const isCurrentDate =
+    fileUpdatedAt.getFullYear() === today.getFullYear() &&
+    fileUpdatedAt.getMonth() === today.getMonth() &&
+    fileUpdatedAt.getDate() === today.getDate();
 
   return (
     <section className="flex flex-col justify-between items-center text-center w-full">
@@ -52,10 +64,24 @@ export const StorageQrCodeDetails: FC<StorageQrCodeDetailsProps> = ({
         </p>
       </div>
       <div className="flex flex-col w-full">
-        <p className="text-text/80 text-sm">
-          {lang.storage.automaticDeleteDate}
-        </p>
-        <p className="text-text text-m">{formatAutoDeleteDate}</p>
+        <p className="text-text/80 text-sm">{lang.storage.automaticDeleteAt}</p>
+        <div className="flex flex-row items-center justify-between w-full">
+          <p className="text-text text-m">{`${formatAutoDeleteDate} ${lang.storage.at} ${autoDeleteTime}`}</p>
+          <div
+            className="h-6 w-6 flex items-center justify-center"
+            title={
+              isCurrentDate
+                ? lang.storage.automaticDeleteAtRefreshTooltipDisabled
+                : lang.storage.automaticDeleteAtRefreshTooltip
+            }
+          >
+            <RefreshIcon
+              className={`h-5 w-5 ${isCurrentDate ? "" : "hover:h-5.5 hover:w-5.5 active:h-5 active:w-5 cursor-pointer"}`}
+              onClick={() => (isCurrentDate ? {} : refreshDeleteDate(file.id))}
+              fill={isCurrentDate ? "#bbbbbb" : "#000000"}
+            />
+          </div>
+        </div>
       </div>
       <Button
         label={lang.buttons.deleteFile}

--- a/client/src/components/StorageQrCodeList.tsx
+++ b/client/src/components/StorageQrCodeList.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState, type FC } from "react";
+import { useCallback, useContext, useEffect, useState, type FC } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { Button } from "./Button";
@@ -26,7 +26,7 @@ export const StorageQrCodeList: FC = () => {
     setHasMounted(true);
   }, []);
 
-  const fetchUserFiles = async () => {
+  const fetchUserFiles = useCallback(async () => {
     const getUserFileResult = await getUserFilesFromSupabase(session);
     if (getUserFileResult.status === "error") {
       toast.error(lang.toast.supabaseGetUserFile[getUserFileResult.errorType]);
@@ -37,12 +37,12 @@ export const StorageQrCodeList: FC = () => {
       const files = getUserFileResult.files;
       setQrCodeFiles(files);
     }
-  };
+  }, [lang.toast.supabaseGetUserFile, navigate, session]);
 
   useEffect(() => {
     if (!hasMounted) return;
     fetchUserFiles();
-  }, [hasMounted, lang.toast.supabaseGetUserFile, navigate, session]);
+  }, [hasMounted, fetchUserFiles]);
 
   const deleteFile = async (fileName: string) => {
     const deleteResult = await deleteFileFromSupabase(fileName, session);

--- a/client/src/components/Topbar.tsx
+++ b/client/src/components/Topbar.tsx
@@ -9,7 +9,7 @@ import GoogleIcon from "../assets/icons/google.svg?react";
 import { useAuthContext } from "../contexts/AuthContext";
 import { LanguageContext } from "../contexts/LanguageContext";
 import { signUp, signOut } from "../services/authenticationService";
-import { DeleteUserAccountFromSupabase } from "../services/storageService";
+import { deleteUserAccountFromSupabase } from "../services/storageService";
 
 export const Topbar: FC = () => {
   const lang = useContext(LanguageContext);
@@ -44,7 +44,7 @@ export const Topbar: FC = () => {
   };
 
   const handleDeleteUserAccountFromSupabase = async () => {
-    const result = await DeleteUserAccountFromSupabase(session);
+    const result = await deleteUserAccountFromSupabase(session);
     if (result.status === "error") {
       toast.error(lang.toast.supabaseDeleteUserAccount[result.errorType]);
       return;

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -66,7 +66,10 @@
     }
   },
   "storage": {
-    "automaticDeleteDate": "Automatic Delete Date",
+    "automaticDeleteAt": "Automatic Delete At",
+    "automaticDeleteAtRefreshTooltip": "Refresh Delete Date to update the automatic delete time",
+    "automaticDeleteAtRefreshTooltipDisabled": "You can only refresh the delete date if the file was not created or updated today",
+    "at": "AT",
     "detailsTitle": "QR Code Details",
     "fileName": "File Name",
     "noFilesDescription": "You haven't uploaded any files yet. Upload a file to generate a QR code",
@@ -109,6 +112,11 @@
     "supabaseGetUserFile": {
       "filesError": "Failed to fetch user files",
       "sessionError": "Failed to validate session. Please sign in again"
+    },
+    "supabaseUpdateFileMetadataTimestamp": {
+      "updateFailed": "Failed to update file metadata timestamp",
+      "sessionError": "Failed to validate session. Please sign in again",
+      "success": "Automatic file delete time updated successfully"
     },
     "supabaseUpload": {
       "fileCountExceeded": "You have reached the maximum file limit of 3. Please delete unused files and try again",

--- a/client/src/services/storageService.ts
+++ b/client/src/services/storageService.ts
@@ -6,6 +6,7 @@ import type {
   SupabaseStorageDeleteResult,
   SupabaseStorageGetUserFilesResult,
   SupabaseStorageUploadResult,
+  SupabaseUpdateUserFileMetadataResult,
 } from "../types/Supabase";
 
 const checkUserFileCount = async (
@@ -27,7 +28,7 @@ const checkUserFileCount = async (
   return tableData.length;
 };
 
-export const DeleteUserAccountFromSupabase = async (
+export const deleteUserAccountFromSupabase = async (
   session: Session | null,
 ): Promise<SupabaseDeleteUserAccountResult> => {
   if (!session || !session.user)
@@ -104,6 +105,27 @@ export const getUserFilesFromSupabase = async (
     status: "success",
     files: files,
   };
+};
+
+export const updateUserFileMetadataTimestamp = async (
+  fileId: string,
+  session: Session | null,
+): Promise<SupabaseUpdateUserFileMetadataResult> => {
+  if (!session || !session.user)
+    return { status: "error", errorType: "sessionError" };
+
+  const { error: updateError } = await supabase
+    .from("user_files")
+    .update({ updated_at: new Date().toISOString() })
+    .eq("id", fileId)
+    .eq("user_id", session.user.id);
+
+  if (updateError) {
+    console.error("Error updating file metadata timestamp:", updateError);
+    return { status: "error", errorType: "updateFailed" };
+  }
+
+  return { status: "success" };
 };
 
 export const uploadFileToSupabase = async (

--- a/client/src/types/Supabase.d.ts
+++ b/client/src/types/Supabase.d.ts
@@ -7,6 +7,13 @@ export type SupabaseDeleteUserAccountResult =
       errorType: "accountDeleteError" | "sessionError" | "signOutError";
     };
 
+export type SupabaseUpdateUserFileMetadataResult =
+  | { status: "success" }
+  | {
+      status: "error";
+      errorType: "updateFailed" | "sessionError";
+    };
+
 export type SupabaseSignOutResult =
   | { status: "success" }
   | { status: "error"; error: AuthError };

--- a/supabase/edge-functions/delete-old-files.ts
+++ b/supabase/edge-functions/delete-old-files.ts
@@ -1,0 +1,133 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.7";
+Deno.serve(async (req) => {
+  try {
+    // Check for the secret key in the request headers
+    const secretKey = req.headers.get("cron-secret-key");
+    const expectedSecretKey = Deno.env.get("CRON_SECRET_KEY");
+    if (!secretKey || secretKey !== expectedSecretKey) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Unauthorized: Invalid or missing secret key",
+        }),
+        {
+          status: 401,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    }
+    // Create a Supabase client with the service role key
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+      {
+        auth: {
+          persistSession: false,
+        },
+      }
+    );
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+    // Fetch files from the `user_files` table that were updated more than 7 days ago
+    const { data: oldFiles, error: fetchError } = await supabaseAdmin
+      .from("user_files")
+      .select("*")
+      .lt("updated_at", sevenDaysAgo.toISOString());
+    if (fetchError) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: fetchError.message,
+        }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    }
+    if (!oldFiles || oldFiles.length === 0) {
+      return new Response(
+        JSON.stringify({
+          success: true,
+          message: "No files older than 7 days found.",
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    }
+    // Extract file paths from the metadata
+    const filePaths = oldFiles.map((file) => file.file_name);
+    // Delete files from the `qr-files` storage bucket
+    const { error: storageDeleteError } = await supabaseAdmin.storage
+      .from("qr-files")
+      .remove(filePaths);
+    if (storageDeleteError) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: storageDeleteError.message,
+        }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    }
+    // Delete file metadata from the `user_files` table  (should be done via functions and triggers after deleting files from storage but doing it here to be sure)
+    const { error: metadataDeleteError } = await supabaseAdmin
+      .from("user_files")
+      .delete()
+      .lt("updated_at", sevenDaysAgo.toISOString());
+    if (metadataDeleteError) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: metadataDeleteError.message,
+        }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    }
+    // Return success response
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: "Old files and metadata deleted successfully.",
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+  } catch (error) {
+    // Handle any unexpected errors
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: error.message,
+      }),
+      {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+  }
+});


### PR DESCRIPTION
- Automatically delete files older than one week using Supabase Edge Functions and cron job
  - Added `pg_cron` and `pg_net` extensions for Supabase
  - Created `delete-old-files` Edge Function that deletes more than week old files from the `qr-files` storage bucket and removes their metadata from the `user_files` table.
  - Created `delete_old_files_cron` job to invoke the `delete-old-files` Edge Function every day at 0:00 and 12:00
  - Secured the Edge Function with a `cron-secret-key` to ensure only authorized requests are processed.
- Implemented refresh mechanism in the client for the automatic file delete date